### PR TITLE
GH docs site build issue

### DIFF
--- a/vendor/go.etcd.io/etcd/raft/README.md
+++ b/vendor/go.etcd.io/etcd/raft/README.md
@@ -69,7 +69,7 @@ To start a three-node cluster
   }
   // Set peer list to the other nodes in the cluster.
   // Note that they need to be started separately as well.
-  n := raft.StartNode(c, []raft.Peer{{ID: 0x02}, {ID: 0x03}})
+  
 ```
 
 Start a single node cluster, like so:


### PR DESCRIPTION
Workaround for 
```
 Your site is having problems building: The variable {{ID: 0x02} on line 72 in vendor/go.etcd.io/etcd/raft/README.md was not properly closed with }}. For more information, see https://docs.github.com/github/working-with-github-pages/troubleshooting-jekyll-build-errors-for-github-pages-sites#tag-not-properly-terminated. 
```