### PR TITLE
Updating the index.yaml version to match appversion

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,7 +3,7 @@ entries:
   aws-efs-csi-driver:
   - apiVersion: v1
     appVersion: 1.0.0
-    created: "2020-12-31T14:52:38.5884209-05:00"
+    created: "2021-01-13T13:29:38.5884209-05:00"
     description: A Helm chart for AWS EFS CSI Driver
     digest: f7f8efd1f201dcee3062b9c37153d737fd9c0d1f2a0983890bd8a456727694f4
     home: https://github.com/kubernetes-sigs/aws-efs-csi-driver
@@ -19,5 +19,5 @@ entries:
     - https://github.com/geekbass/aws-efs-csi-driver
     urls:
     - https://github.com/geekbass/aws-efs-csi-driver/releases/download/v1.0.2/helm-chart.tgz
-    version: 0.1.1
-generated: "2020-12-31T14:52:38.5867514-05:00"
+    version: 1.0.0
+generated: "2021-01-13T13:29:49.5867514-05:00"


### PR DESCRIPTION
**Is this a bug fix or adding new feature?** Fix

**What is this PR about? / Why do we need it?** Mismatched versions between charts.yaml and index.yaml are causing failure deployments. I cannot understand what it is supposed to be so setting to match appVersion.

**What testing is done?** 
